### PR TITLE
Add note for OS X 10.8 Mountain Lion

### DIFF
--- a/content/css/style.scss
+++ b/content/css/style.scss
@@ -952,6 +952,19 @@ h1 > #action:before {
 }
 
 
+/* Installation
+--------------------------------------------- */
+#main section .note {
+  background-color: #FFF9D8;
+  border: 1px solid #EEE8C7;
+  padding: 0px;
+}
+
+#main section .note p {
+  margin: 0px;
+  padding: 5px;
+}
+
 /* About
 --------------------------------------------- */
 

--- a/content/install_mac.html
+++ b/content/install_mac.html
@@ -33,6 +33,19 @@ subnav:
     <p>However, it is not recommended that you use the system installation,
     so we show you how to install with RVM. If you already have Ruby 1.9.2
     installed, skip to Step 4.</p>
+
+    <div class='note'>
+      <p><strong>Note for OS 10.8 - Mountain Lion</strong></p>
+      
+      <p>
+        The command line developer tools required for installation are no
+        longer included by default with Xcode and must be downloaded separately
+        from
+        <a href='http://stackoverflow.com/questions/9353444/how-to-use-install-gcc-on-mac-os-x-10-8-xcode-4-4'>within Xcode</a>
+        or directly from Apple's
+        <a href='https://developer.apple.com/downloads/index.action?name=for%20Xcode%20-'>Developer Site</a>.
+      </p>
+    </div>
   </section>
   <section>
     <h1>Installing Ruby and SproutCore</h1>


### PR DESCRIPTION
The latest version of Xcode no longer includes the command line
developer tools and must be installed separately.
